### PR TITLE
Add unmapped instructions for autoware and geekbench

### DIFF
--- a/src/pin/pin_lib/x86_decoder.cc
+++ b/src/pin/pin_lib/x86_decoder.cc
@@ -1978,10 +1978,10 @@ void init_pin_opcode_convert(void) {
   iclass_to_scarab_map[XED_ICLASS_KORD] = {OP_LOGIC, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPSIGNW] = {OP_CMOV, 2, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPHADDD] = {OP_IADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPDPBUSDS] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPDPBUSDS] = {OP_PIPELINED_SLOW, 4, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VHADDPS] = {OP_FADD, 4, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VLDDQU] = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPHMINPOSUW] = {OP_PIPELINED_MEDIUM, 2, 8, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPHMINPOSUW] = {OP_PIPELINED_SLOW, 2, 8, NONE};
   iclass_to_scarab_map[XED_ICLASS_PDEP] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VHADDPD] = {OP_FADD, 8, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_PEXT] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};

--- a/src/pin/pin_lib/x86_decoder.cc
+++ b/src/pin/pin_lib/x86_decoder.cc
@@ -1973,7 +1973,7 @@ void init_pin_opcode_convert(void) {
   iclass_to_scarab_map[XED_ICLASS_BZHI] = {OP_LOGIC, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPCMPUB] = {OP_LOGIC, 1, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPTESTMB] = {OP_LOGIC, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RDSEED] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RDSEED] = {OP_NOTPIPELINED_VERY_SLOW, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_KORTESTD] = {OP_LOGIC, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_KORD] = {OP_LOGIC, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPSIGNW] = {OP_CMOV, 2, -1, NONE};

--- a/src/pin/pin_lib/x86_decoder.cc
+++ b/src/pin/pin_lib/x86_decoder.cc
@@ -1970,4 +1970,19 @@ void init_pin_opcode_convert(void) {
                                             NONE};
   iclass_to_scarab_map[XED_ICLASS_XSAVEC]   = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
                                              NONE};
+  iclass_to_scarab_map[XED_ICLASS_BZHI] = {OP_LOGIC,  -1,  1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPUB] = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPTESTMB] = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RDSEED] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KORTESTD] = { OP_LOGIC, -1, 1, NONE };
+  iclass_to_scarab_map[XED_ICLASS_KORD] = { OP_LOGIC, -1, 1, NONE };
+  iclass_to_scarab_map[XED_ICLASS_VPSIGNW] = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPHADDD] = {OP_IADD,           4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPDPBUSDS] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VHADDPS] = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VLDDQU] = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPHMINPOSUW] = {OP_PIPELINED_MEDIUM, 2, 8, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PDEP] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VHADDPD] = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PEXT] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
 }

--- a/src/pin/pin_lib/x86_decoder.cc
+++ b/src/pin/pin_lib/x86_decoder.cc
@@ -1970,14 +1970,14 @@ void init_pin_opcode_convert(void) {
                                             NONE};
   iclass_to_scarab_map[XED_ICLASS_XSAVEC]   = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
                                              NONE};
-  iclass_to_scarab_map[XED_ICLASS_BZHI] = {OP_LOGIC,  -1,  1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BZHI] = {OP_LOGIC, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPCMPUB] = {OP_LOGIC, 1, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPTESTMB] = {OP_LOGIC, 1, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_RDSEED] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KORTESTD] = { OP_LOGIC, -1, 1, NONE };
-  iclass_to_scarab_map[XED_ICLASS_KORD] = { OP_LOGIC, -1, 1, NONE };
+  iclass_to_scarab_map[XED_ICLASS_KORTESTD] = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KORD] = {OP_LOGIC, -1, 1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPSIGNW] = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPHADDD] = {OP_IADD,           4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPHADDD] = {OP_IADD, 4, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VPDPBUSDS] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VHADDPS] = {OP_FADD, 4, -1, NONE};
   iclass_to_scarab_map[XED_ICLASS_VLDDQU] = {OP_MOV, -1, 1, NONE};


### PR DESCRIPTION
Environment : Cascade Lake(Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz)

elem(PIPELINED_FAST) /* i.e. <=2 cycles, pipelined /
elem(PIPELINED_MEDIUM) / i.e. <=5 cycles, pipelined /
elem(PIPELINED_SLOW) / i.e. > 5 cycles, pipelined /
elem(NOTPIPELINED_MEDIUM) / i.e. <=5 cycles, not pipelined /
elem(NOTPIPELINED_SLOW) / i.e. >5 cycles, not pipelined /
elem(NOTPIPELINED_VERY_SLOW) / i.e. >50 cycles, not pipelined */

iclass_to_scarab_map[XED_ICLASS_RDSEED] = {OP_NOTPIPELINED_VERY_SLOW, -1, 1, NONE};
RDSEED : The core cycles ranges for this instruction is 550 to 650. (VERY SLOW)
With 1 independent inst, core cycles : 607
With 13 independent inst, core cycles : 581 (7561/13)

iclass_to_scarab_map[XED_ICLASS_PDEP] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
Latency operand 2 → 1: 3
Latency operand 3 → 1 (address, base register): 8
Latency operand 3 → 1 (address, index register): 8
Latency operand 3 → 1 (memory): ≤5
The avg cycles across all cases is about 6 cycles. (SLOW)

iclass_to_scarab_map[XED_ICLASS_PEXT] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
Latency operand 2 → 1: 3
Latency operand 3 → 1 (address, base register): 8
Latency operand 3 → 1 (address, index register): 8
Latency operand 3 → 1 (memory): ≤5
The avg cycles across all cases is about 6 cycles. (SLOW)

iclass_to_scarab_map[XED_ICLASS_VPDPBUSDS] = {OP_PIPELINED_SLOW, 4, -1, NONE};
Latency operand 1 → 1: 5
Latency operand 2 → 1: 5
Latency operand 3 → 1: 5
Latency operand 4 → 1 (address, base register): ≤12
Latency operand 4 → 1 (address, index register): ≤12
Latency operand 4 → 1 (memory): ≤9
The avg cycles across all cases is about 8 cycles. (SLOW)

iclass_to_scarab_map[XED_ICLASS_VPHMINPOSUW] = {OP_PIPELINED_SLOW, 2, 8, NONE};
Latency operand 2 → 1 (address, base register): ≤11
Latency operand 2 → 1 (address, index register): ≤11
Latency operand 2 → 1 (memory): ≤8
The avg cycles across all cases is about 10 cycles. (SLOW)

ref : https://uops.info/table.html