### PR TITLE
memtrace/pt: make pid/tid frontend state per-core

### DIFF
--- a/src/frontend/pt_memtrace/memtrace_fe.cc
+++ b/src/frontend/pt_memtrace/memtrace_fe.cc
@@ -64,8 +64,8 @@ TraceReader* trace_readers[MAX_NUM_PROCS];
 // TODO: Make per proc?
 uint64_t ins_id = 0;
 uint64_t ins_id_fetched = 0;
-uint64_t prior_tid = 0;
-uint64_t prior_pid = 0;
+uint64_t prior_tid[MAX_NUM_PROCS] = {0};
+uint64_t prior_pid[MAX_NUM_PROCS] = {0};
 
 extern scatter_info_map scatter_info_storage;
 
@@ -177,13 +177,13 @@ int memtrace_trace_read(int proc_id, ctype_pin_inst* next_onpath_pi) {
   do {
     insi = const_cast<InstInfo*>(trace_readers[proc_id]->nextInstruction());
 
-    if (prior_pid == 0) {
-      ASSERT(proc_id, prior_tid == 0);
+    if (prior_pid[proc_id] == 0) {
+      ASSERT(proc_id, prior_tid[proc_id] == 0);
       ASSERT(proc_id, insi->valid);
-      prior_pid = insi->pid;
-      prior_tid = insi->tid;
-      ASSERT(proc_id, prior_tid);
-      ASSERT(proc_id, prior_pid);
+      prior_pid[proc_id] = insi->pid;
+      prior_tid[proc_id] = insi->tid;
+      ASSERT(proc_id, prior_tid[proc_id]);
+      ASSERT(proc_id, prior_pid[proc_id]);
     }
     if (insi->valid) {
       ins_id++;
@@ -194,7 +194,7 @@ int memtrace_trace_read(int proc_id, ctype_pin_inst* next_onpath_pi) {
       std::cout << "Reached end of trace" << std::endl;
       return 0;  // end of trace
     }
-  } while (insi->pid != prior_pid || insi->tid != prior_tid);
+  } while (insi->pid != prior_pid[proc_id] || insi->tid != prior_tid[proc_id]);
 
   if (insi->is_dr_ins) {
     memcpy(next_onpath_pi, insi->info, sizeof(ctype_pin_inst));
@@ -245,6 +245,8 @@ void memtrace_init(void) {
   uop_generator_init(NUM_CORES);
   init_x86_decoder(nullptr);
   init_x87_stack_delta();
+  memset(prior_tid, 0, sizeof(prior_tid));
+  memset(prior_pid, 0, sizeof(prior_pid));
 
   // next_onpath_pi = (ctype_pin_inst*)malloc(NUM_CORES * sizeof(ctype_pin_inst));
 

--- a/src/frontend/pt_memtrace/memtrace_fe.cc
+++ b/src/frontend/pt_memtrace/memtrace_fe.cc
@@ -61,7 +61,6 @@ extern "C" {
 
 static char* trace_files[MAX_NUM_PROCS];
 TraceReader* trace_readers[MAX_NUM_PROCS];
-// TODO: Make per proc?
 uint64_t ins_id = 0;
 uint64_t ins_id_fetched = 0;
 uint64_t prior_tid[MAX_NUM_PROCS] = {0};
@@ -245,8 +244,6 @@ void memtrace_init(void) {
   uop_generator_init(NUM_CORES);
   init_x86_decoder(nullptr);
   init_x87_stack_delta();
-  memset(prior_tid, 0, sizeof(prior_tid));
-  memset(prior_pid, 0, sizeof(prior_pid));
 
   // next_onpath_pi = (ctype_pin_inst*)malloc(NUM_CORES * sizeof(ctype_pin_inst));
 

--- a/src/frontend/pt_memtrace/pt_fe.cc
+++ b/src/frontend/pt_memtrace/pt_fe.cc
@@ -67,8 +67,8 @@ extern "C" {
 char* pt_trace_files[MAX_NUM_PROCS];
 TraceReaderPT* pt_trace_readers[MAX_NUM_PROCS];
 uint64_t pt_ins_id = 0;
-uint64_t pt_prior_tid = 0;
-uint64_t pt_prior_pid = 0;
+uint64_t pt_prior_tid[MAX_NUM_PROCS] = {0};
+uint64_t pt_prior_pid[MAX_NUM_PROCS] = {0};
 
 std::mt19937 gen(0);
 // Generate random addresses near the mean (1GB)
@@ -146,7 +146,7 @@ int pt_trace_read(int proc_id, ctype_pin_inst* pt_next_pi) {
     pt_ins_id++;
     if (!insi->valid)
       return 0;  // end of trace
-  } while (insi->pid != pt_prior_pid || insi->tid != pt_prior_tid);
+  } while (insi->pid != pt_prior_pid[proc_id] || insi->tid != pt_prior_tid[proc_id]);
 
   init_ctype_pin_inst(pt_next_pi);
   pt_fill_in_dynamic_info(pt_next_pi, insi);
@@ -179,6 +179,8 @@ void pt_init(void) {
   uop_generator_init(NUM_CORES);
   init_x86_decoder(nullptr);
   init_x87_stack_delta();
+  memset(pt_prior_tid, 0, sizeof(pt_prior_tid));
+  memset(pt_prior_pid, 0, sizeof(pt_prior_pid));
 
   // pt_next_pi = (ctype_pin_inst*)malloc(NUM_CORES * sizeof(ctype_pin_inst));
   for (int i = 0; i < MAX_NUM_PROCS; ++i) {
@@ -236,8 +238,8 @@ void pt_setup(uns proc_id) {
     std::cout << "Exit fast forward " << pt_ins_id << std::endl;
   }
 
-  pt_prior_pid = insi->pid;
-  pt_prior_tid = insi->tid;
-  assert(pt_prior_tid);
-  assert(pt_prior_pid);
+  pt_prior_pid[proc_id] = insi->pid;
+  pt_prior_tid[proc_id] = insi->tid;
+  assert(pt_prior_tid[proc_id]);
+  assert(pt_prior_pid[proc_id]);
 }

--- a/src/frontend/pt_memtrace/trace_fe.cc
+++ b/src/frontend/pt_memtrace/trace_fe.cc
@@ -370,8 +370,13 @@ void ext_trace_init() {
     memtrace_init();
 
   trace_buf_init();
-  for (uns proc_id = 0; proc_id < NUM_CORES; proc_id++)
-    trace_read(proc_id, &next_onpath_pi[proc_id]);
+  for (uns proc_id = 0; proc_id < NUM_CORES; proc_id++) {
+    if (!trace_read(proc_id, &next_onpath_pi[proc_id])) {
+      // Allow cores whose trace cannot provide an initial instruction to be treated as finished.
+      trace_read_done[proc_id] = TRUE;
+      reached_exit[proc_id] = TRUE;
+    }
+  }
 }
 
 void ext_trace_done() {

--- a/src/frontend/pt_memtrace/trace_fe.cc
+++ b/src/frontend/pt_memtrace/trace_fe.cc
@@ -371,11 +371,7 @@ void ext_trace_init() {
 
   trace_buf_init();
   for (uns proc_id = 0; proc_id < NUM_CORES; proc_id++) {
-    if (!trace_read(proc_id, &next_onpath_pi[proc_id])) {
-      // Allow cores whose trace cannot provide an initial instruction to be treated as finished.
-      trace_read_done[proc_id] = TRUE;
-      reached_exit[proc_id] = TRUE;
-    }
+    ASSERT(proc_id, trace_read(proc_id, &next_onpath_pi[proc_id]));
   }
 }
 


### PR DESCRIPTION
- Fixes multicore frontend state handling where pid/tid context was effectively shared across cores.
- Makes pid/tid handling per-core in the memtrace/PT frontend path.
- Also handles empty initial trace read safely during frontend initialization
- Validated on multicore workloads where the issue previously reproduced.